### PR TITLE
Update screen-keys.conf to escape backslash

### DIFF
--- a/examples/screen-keys.conf
+++ b/examples/screen-keys.conf
@@ -72,8 +72,8 @@ unbind w
 bind w list-windows
 
 # quit \ 
-unbind \
-bind \ confirm-before "kill-server"
+unbind \\
+bind \\ confirm-before "kill-server"
 
 # kill K k 
 unbind K


### PR DESCRIPTION
In tmux on RHEL9 the backslash to quit must be escaped in the config file otherwise tmux views it as an invalid escape sequence.